### PR TITLE
Allow component to accept a backgroundColor for the animated view (Panel)

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,19 +79,11 @@ export default Example;
 ```
 
 ### Props
-
-##### `height` - integer (`required`)
-
-Sets the panel size.
-
-##### `radius` - integer (`Default - 10`)
-
-Sets the radius of the top borders.
-
-##### `hasDraggableIcon` - boolean (`Default - false`)
-
-Controls visibility of the draggable icon on top of the modal.
-
-##### `draggable` - boolean (`Default - true`)
-
-Specify whether the panel is draggable or not.
+| name                      | required | default | Type    | description |
+| ------------------------- | -------- | ----------| --------| ------------|
+| height                    | Yes      |           | integer | Determines the panel size.|
+| radius                    | No       | 10        | integer | Determines the radius of the top borders.|
+| hasDraggableIcon          | No       | false     | boolean | Controls visibility of the draggable icon on top of the modal.|
+| draggable                 | No       | true      | boolean | Specify whether the panel is draggable or not.|
+| backgroundColor           | No       |`#25252599`| string  | Change the color of the overlay.|    
+| sheetBackgroundColor      | No       |`#F3F3F3`  | string  | Change the background of the panel.|    

--- a/src/BottomSheet/index.js
+++ b/src/BottomSheet/index.js
@@ -53,7 +53,9 @@ class BottomSheet extends Component {
       onStartShouldSetPanResponder: () => true,
       onPanResponderMove: (e, gestureState) => {
         if (gestureState.dy > 0) {
-          Animated.event([null, { dy: pan.y }])(e, gestureState);
+          Animated.event([null, { dy: pan.y }], {
+            useNativeDriver: false,
+          })(e, gestureState);
         }
       },
       onPanResponderRelease: (e, gestureState) => {
@@ -81,6 +83,7 @@ class BottomSheet extends Component {
       children,
       hasDraggableIcon,
       backgroundColor,
+      sheetBackgroundColor,
       dragIconColor,
       draggable = true,
       onRequestClose,
@@ -92,46 +95,47 @@ class BottomSheet extends Component {
     };
 
     return (
-      <Modal transparent visible={modalVisible} onRequestClose={onRequestClose}>
-        <View
-          style={[
-            styles.wrapper,
-            { backgroundColor: backgroundColor || "#25252599" },
-          ]}
-        >
-          <TouchableOpacity
-            style={styles.background}
-            activeOpacity={1}
-            onPress={() => this.close()}
-          />
-          <Animated.View
-            {...(draggable && this.panResponder.panHandlers)}
-            style={[
-              panStyle,
-              styles.container,
-              {
-                height: animatedHeight,
-                borderTopRightRadius: radius || 10,
-                borderTopLeftRadius: radius || 10,
-              },
-            ]}
+        <Modal transparent visible={modalVisible} onRequestClose={onRequestClose}>
+          <View
+              style={[
+                styles.wrapper,
+                { backgroundColor: backgroundColor || "#25252599" },
+              ]}
           >
-            {hasDraggableIcon && (
-              <View style={styles.draggableContainer}>
-                <View
-                  style={[
-                    styles.draggableIcon,
-                    {
-                      backgroundColor: dragIconColor || "#A3A3A3",
-                    },
-                  ]}
-                />
-              </View>
-            )}
-            {children}
-          </Animated.View>
-        </View>
-      </Modal>
+            <TouchableOpacity
+                style={styles.background}
+                activeOpacity={1}
+                onPress={() => this.close()}
+            />
+            <Animated.View
+                {...(draggable && this.panResponder.panHandlers)}
+                style={[
+                  panStyle,
+                  styles.container,
+                  {
+                    height: animatedHeight,
+                    borderTopRightRadius: radius || 10,
+                    borderTopLeftRadius: radius || 10,
+                    backgroundColor: sheetBackgroundColor || "#F3F3F3",
+                  },
+                ]}
+            >
+              {hasDraggableIcon && (
+                  <View style={styles.draggableContainer}>
+                    <View
+                        style={[
+                          styles.draggableIcon,
+                          {
+                            backgroundColor: dragIconColor || "#A3A3A3",
+                          },
+                        ]}
+                    />
+                  </View>
+              )}
+              {children}
+            </Animated.View>
+          </View>
+        </Modal>
     );
   }
 }

--- a/src/BottomSheet/styles.js
+++ b/src/BottomSheet/styles.js
@@ -10,7 +10,6 @@ const styles = StyleSheet.create({
     backgroundColor: "transparent",
   },
   container: {
-    backgroundColor: "#F3F3F3",
     width: "100%",
     height: 0,
     overflow: "hidden",


### PR DESCRIPTION
This PR allows for developers to enable their own dark mode background colour by setting the `sheetBackgroundColor` to their own colour choice.

Changes: 

- Added Config options to `Animate.event` with an option of `useNativeDriver: false` to fix the warnings.
- Removed `backgroundColor` from container in `styles.js` and replaced it in `index.js line 119`  to accept the `sheetBackgroundColor` prop with a default of the original colour `#F3F3F3`.
- Updated` README.md` to show props more visually in a table with previous descriptions and added props to enable full view of component props.

It's a very nice component to be working with `props` to you for sharing it with the community.

Any questions let me know.  