### PR TITLE
Fix useNativeDriver warning on sheet open

### DIFF
--- a/src/BottomSheet/index.js
+++ b/src/BottomSheet/index.js
@@ -64,7 +64,7 @@ class BottomSheet extends Component {
         if (gestureDistance > gestureLimitArea) {
           this.setModalVisible(false);
         } else {
-          Animated.spring(pan, { toValue: { x: 0, y: 0 } }).start();
+          Animated.spring(pan, { toValue: { x: 0, y: 0 }, useNativeDriver: false, }).start();
         }
       },
     });


### PR DESCRIPTION
Did one very simple thing:

* Added a `useNativeDriver: false` to the spring animation so that the warning would go away.